### PR TITLE
Store Translations in local Session for quick loading

### DIFF
--- a/config/dom_translate.php
+++ b/config/dom_translate.php
@@ -1,12 +1,16 @@
 <?php
 // return config
 return [
-    // the level of logging. We suggest using either 0 or 1 for Prod environments.
+    // If true, located 'phrase' => 'translation' pairs will be stored in local session too.
+    // The normal functionality (DB storing) will still exists, this simply adds a layer above
+    // to not call the DB if a session translation can be found.
+    'use_session' => env('DOM_TRANSLATE_USE_SESSION', true),
+    // The level of logging. We suggest using either 0 or 1 for Prod environments.
     'logging' => [
         'level' => env('DOM_TRANSLATE_LOG_LEVEL', 3), // 0=None; 1=High-Level; 2=Mid-Level or 3=Low-Level
         'indicator' => env('DOM_TRANSLATE_LOG_INDICATOR', 'dom-translate'), // Log indicator to find items in the log file.
     ],
-    // 3rd party translation service providers
+    // 3rd party translation service providers.
     'api' => [
         'provider' => env('DOM_TRANSLATE_PROVIDER', 'google'),
         'google' => [
@@ -15,14 +19,16 @@ return [
             'action' => "POST",
             'key' => env('DOM_TRANSLATE_GOOGLE_KEY'), // https://console.cloud.google.com/apis/credentials
         ],
-        // @todo - add more translate providers here... (and their \ApiTranslate\Class)
+        // @todo - for developers wanting to contibute:
+        // fork the project and add more translate providers here... (and their \ApiTranslate\Class implementing CloudTranslateInterface)
+        // ... thanks ;)
     ],
-    // below details will be used to hash a given phrase for quick loading (via index)
+    // Below details will be used to hash a given phrase for quick loading (via index)
     'hash' => [
         'salt' => env('DOM_TRANSLATE_HASH_SALT', 'zBQ2DxKhNa'),
         'algo' => env('DOM_TRANSLATE_HASH_ALGO', 'sha1'), // https://www.php.net/manual/en/function.hash-algos.php
     ],
-    // Only ISO-639-1 format: @link: https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
+    // Only ISO-639-1 formats: @link: https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
     'language' => [
         'src' => env('DOM_TRANSLATE_LANG_SRC', 'en'), // default source language
         'dest' => env('DOM_TRANSLATE_LANG_DEST', 'af'), // default destination language

--- a/src/Helpers/phraseHelper.php
+++ b/src/Helpers/phraseHelper.php
@@ -42,4 +42,26 @@ class phraseHelper
             config('dom_translate.hash.salt')
         );
     }
+
+    /**
+     * Return the correctly defined Destination Language Code
+     *
+     * @param string $destCode
+     * @return string
+     */
+    public static function prepDestLanguage(?string $destCode = null)
+    {
+        return trim(strtolower(!empty($destCode) ? $destCode : config('dom_translate.language.dest')));
+    }
+
+    /**
+     * Return the correctly defined Source Language Code
+     *
+     * @param string $srcCode
+     * @return string
+     */
+    public static function prepSrcLanguage(?string $srcCode = null)
+    {
+        return trim(strtolower(!empty($srcCode) ? $srcCode : config('dom_translate.language.src')));
+    }
 }


### PR DESCRIPTION
Enabled the ability to store the DB located phrase translation in the local session for super-quick loading. 
**Note:** All Phrase->Translations will still be stored in the DB *(as per normal)* but enabling this feature (via conf) would ensure that the DB would not be queried if a session key pair exists.